### PR TITLE
added space in category property for Tennessine

### DIFF
--- a/PeriodicTableJSON.json
+++ b/PeriodicTableJSON.json
@@ -3280,7 +3280,7 @@
             "appearance": null, 
             "atomic_mass": 294, 
             "boil": 883, 
-            "category": "unknown,probably metalloid", 
+            "category": "unknown, probably metalloid", 
             "color": null, 
             "density": 7.17, 
             "discovered_by": "Joint Institute for Nuclear Research", 


### PR DESCRIPTION
I noticed a typo for Tennessine and fixed it. There's a space missing after the comma in the category property.