### PR TITLE
Density of Bromine 23.1028 --> 3.1028

### DIFF
--- a/PeriodicTableJSON.json
+++ b/PeriodicTableJSON.json
@@ -929,7 +929,7 @@
             "boil": 332.0, 
             "category": "diatomic nonmetal", 
             "color": null, 
-            "density": 23.1028, 
+            "density": 3.1028, 
             "discovered_by": "Antoine J\u00e9r\u00f4me Balard", 
             "melt": 265.8, 
             "molar_heat": null, 


### PR DESCRIPTION
The density of Bromine is 3.1028 not 23.1028.
Source https://en.wikipedia.org/wiki/Bromine