### PR TITLE
Fix typo "repersented"

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 A json of the entire periodic table. Feel free to use it in your projects.
 
 Temperatures such as boiling points and melting points are given in degrees kelvin.  Densities are given in g/L and molar heat in (mol*K)
-Information that is missing is repersented as null. Some elements may have an image link to their spectral bands.
+Information that is missing is represented as null. Some elements may have an image link to their spectral bands.
 
 All elements have a three sentence summary from Wikipedia. Currently the color tag is useless, so please use appearance instead.
 


### PR DESCRIPTION
Corrects an easy-to-miss typo. :+1: