### PR TITLE
Change Kelvin nomenclature on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Periodic-Table-JSON
 A json of the entire periodic table. Feel free to use it in your projects.
 
-Temperatures such as boiling points and melting points are given in degrees kelvin.  Densities are given in g/l for gases and g/cm³ for solids and liquids and molar heat in (mol*K).
+Temperatures such as boiling points and melting points are given in Kelvin.  Densities are given in g/l for gases and g/cm³ for solids and liquids and molar heat in (mol*K).
 Information that is missing is represented as null. Some elements may have an image link to their spectral bands.
 
 All elements have a three sentence summary from Wikipedia.


### PR DESCRIPTION
The Kelvin scale isn't named with "degree" like in "degrees Celsius" (ᵒC) or "degrees Fahrenheit" (ᵒF). The internationally accepted naming is just "Kelvin" (K) (see [here](https://www.newworldencyclopedia.org/entry/kelvin) and [here](https://www.physlink.com/education/askexperts/ae369.cfm)).

This PR updates the text on README.md to the correct nomenclature.