### PR TITLE
Add missing whitespace in Ts summary

### DIFF
--- a/PeriodicTableJSON.json
+++ b/PeriodicTableJSON.json
@@ -6141,7 +6141,7 @@
             "bohr_model_image": "https://storage.googleapis.com/search-ar-edu/periodic-table/element_117_tennessine/element_117_tennessine_srp_th.png",
             "bohr_model_3d": "https://storage.googleapis.com/search-ar-edu/periodic-table/element_117_tennessine/element_117_tennessine.glb",
             "spectral_img": null,
-            "summary": "Tennessine is a superheavy artificial chemical element with an atomic number of 117 and a symbol of Ts. Also known as eka-astatine or element 117, it is the second-heaviest known element and penultimate element of the 7th period of the periodic table. As of 2016, fifteen tennessine atoms have been observed:six when it was first synthesized in 2010, seven in 2012, and two in 2014.",
+            "summary": "Tennessine is a superheavy artificial chemical element with an atomic number of 117 and a symbol of Ts. Also known as eka-astatine or element 117, it is the second-heaviest known element and penultimate element of the 7th period of the periodic table. As of 2016, fifteen tennessine atoms have been observed: six when it was first synthesized in 2010, seven in 2012, and two in 2014.",
             "symbol": "Ts",
             "xpos": 17,
             "ypos": 7,


### PR DESCRIPTION
I noticed, that there was a whitespace missing, in the Tennessine summary in the [main json](https://github.com/Bowserinator/Periodic-Table-JSON/blob/f5b9327e56cb56d189e952d9f60375a4964fc829/PeriodicTableJSON.json#L6144) so added it. I was not sure if I had to run the scripts to update the other files but didn't do this by now. Please inform me if I have to do this.

BTW, I am using your database in a webproject of mine and I really appreciate it's existence!
Sry for my bad english...